### PR TITLE
Add `/v2` to the  API URL in PluralKit

### DIFF
--- a/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/storage/PKGuildConfig.kt
+++ b/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/storage/PKGuildConfig.kt
@@ -24,7 +24,7 @@ data class PKGuildConfig(
     @TomlComment(
         "Base URL to use when attempting to hit the PluralKit API, without the /vX used to specify the version."
     )
-    var apiUrl: String = "https://api.pluralkit.me",
+    var apiUrl: String = "https://api.pluralkit.me/v2",
 
     @TomlComment(
         "The ID of the PluralKit instance to use, if not the default instance."


### PR DESCRIPTION
This prevents the `/v2` vanishing entirely from the search URL when no explicit URL is provided in the local PK config